### PR TITLE
Black series support, correcting some effect values in the Blue series, and some general cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,16 @@
   [Home Assistant Forum Post](https://community.home-assistant.io/t/control-leds-and-led-effects-on-inovelli-dimmers-switches-and-combo-fan-lights-by-area-device-or-entity/421862)
 
   Supported Inovelli devices:
-  * [LZW30 Black 500 Series switch](https://help.inovelli.com/en/articles/8454923-black-series-on-off-switch-manual)
-  * [LZW31 Black 500 series dimmer](https://inovelli.com/products/z-wave-black-series-smart-dimmer-switch)
-  * [LZW30-SN Red 500 Series switch](https://help.inovelli.com/en/articles/8453781-red-series-on-off-switch-manual)
-  * [LZW31-SN Red 500 Series dimmer](https://help.inovelli.com/en/articles/8319390-red-series-dimmer-switch-manual)
-  * [LZW36 Red 500 Series fan / light combo](https://help.inovelli.com/en/articles/8483467-red-series-fan-light-switch-manual)
-  * [VZW31-SN Red 800 Series 2-in-1 dimmer](https://inovelli.com/products/z-wave-800-red-series-smart-2-1-on-off-dimmer-switch)
-  * [VZM31-SN Blue Series (Zigbee) 2-in-1 dimmer](https://inovelli.com/en-ca/products/zigbee-matter-blue-series-smart-2-1-on-off-dimmer-switch)
+  * Z-Wave:
+    * [LZW30 Black 500 Series switch](https://help.inovelli.com/en/articles/8454923-black-series-on-off-switch-manual)
+    * [LZW31 Black 500 series dimmer](https://inovelli.com/products/z-wave-black-series-smart-dimmer-switch)
+    * [LZW30-SN Red 500 Series switch](https://help.inovelli.com/en/articles/8453781-red-series-on-off-switch-manual)
+    * [LZW31-SN Red 500 Series dimmer](https://help.inovelli.com/en/articles/8319390-red-series-dimmer-switch-manual)
+    * [LZW36 Red 500 Series fan / light combo](https://help.inovelli.com/en/articles/8483467-red-series-fan-light-switch-manual)
+    * [VZW31-SN Red 800 Series 2-in-1 dimmer](https://inovelli.com/products/z-wave-800-red-series-smart-2-1-on-off-dimmer-switch)
+  * Zigbee:
+    * [VZM31-SN Blue Series (Zigbee) 2-in-1 dimmer](https://inovelli.com/en-ca/products/zigbee-matter-blue-series-smart-2-1-on-off-dimmer-switch)
+    * [Inovelli Fan Controller (VZM35-SN)](https://inovelli.com/products/blue-series-fan-switch-zigbee-3-0)
   
   
     

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   * Zigbee:
     * [VZM31-SN Blue Series 2-in-1 Dimmer](https://inovelli.com/en-ca/products/zigbee-matter-blue-series-smart-2-1-on-off-dimmer-switch)
     * [VZM35-SN Blue Series 3-Speed Fan Switch](https://inovelli.com/products/blue-series-fan-switch-zigbee-3-0)
+    * [DZM32-SN Blue Series mmWave Presence Sensor Dimmer](https://inovelli.com/products/zigbee-matter-blue-series-mmwave-presence-sensor-smart-dimmer-switch)
   
   
     

--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@
   * Zigbee:
     * [VZM31-SN Blue Series 2-in-1 Dimmer](https://inovelli.com/en-ca/products/zigbee-matter-blue-series-smart-2-1-on-off-dimmer-switch)
     * [VZM35-SN Blue Series 3-Speed Fan Switch](https://inovelli.com/products/blue-series-fan-switch-zigbee-3-0)
-    * [DZM32-SN Blue Series mmWave Presence Sensor Dimmer](https://inovelli.com/products/zigbee-matter-blue-series-mmwave-presence-sensor-smart-dimmer-switch)
   
   
-    
   **Features**
   This script can set and clear effects as well as configure the LED or LED strip on Inovelli dimmers, switches, and fan / light combo dimmers.  Devices of different types can be set in a single call.  It will accept entities of Inovelli devices, the device itself in the form of the device ID, or an area ID to set all Inovelli devices in that area.
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
   [Home Assistant Forum Post](https://community.home-assistant.io/t/control-leds-and-led-effects-on-inovelli-dimmers-switches-and-combo-fan-lights-by-area-device-or-entity/421862)
 
   Supported Inovelli devices:
-  * LZW30-SN Red Series switch
-  * LZW31-SN Red Series dimmer
-  * LZW36 Red Series fan / light combo
+  * [LZW30 Black 500 Series switch](https://help.inovelli.com/en/articles/8454923-black-series-on-off-switch-manual)
+  * [LZW31 Black 500 series dimmer](https://inovelli.com/products/z-wave-black-series-smart-dimmer-switch)
+  * [LZW30-SN Red 500 Series switch](https://help.inovelli.com/en/articles/8453781-red-series-on-off-switch-manual)
+  * [LZW31-SN Red 500 Series dimmer](https://help.inovelli.com/en/articles/8319390-red-series-dimmer-switch-manual)
+  * [LZW36 Red 500 Series fan / light combo](https://help.inovelli.com/en/articles/8483467-red-series-fan-light-switch-manual)
   * [VZW31-SN Red 800 Series 2-in-1 dimmer](https://inovelli.com/products/z-wave-800-red-series-smart-2-1-on-off-dimmer-switch)
   * [VZM31-SN Blue Series (Zigbee) 2-in-1 dimmer](https://inovelli.com/en-ca/products/zigbee-matter-blue-series-smart-2-1-on-off-dimmer-switch)
   

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 
   Supported Inovelli devices:
   * Z-Wave:
-    * [LZW30 Black 500 Series switch](https://help.inovelli.com/en/articles/8454923-black-series-on-off-switch-manual)
-    * [LZW31 Black 500 series dimmer](https://inovelli.com/products/z-wave-black-series-smart-dimmer-switch)
-    * [LZW30-SN Red 500 Series switch](https://help.inovelli.com/en/articles/8453781-red-series-on-off-switch-manual)
-    * [LZW31-SN Red 500 Series dimmer](https://help.inovelli.com/en/articles/8319390-red-series-dimmer-switch-manual)
-    * [LZW36 Red 500 Series fan / light combo](https://help.inovelli.com/en/articles/8483467-red-series-fan-light-switch-manual)
-    * [VZW31-SN Red 800 Series 2-in-1 dimmer](https://inovelli.com/products/z-wave-800-red-series-smart-2-1-on-off-dimmer-switch)
+    * [LZW30 Black 500 Series Switch](https://help.inovelli.com/en/articles/8454923-black-series-on-off-switch-manual)
+    * [LZW31 Black 500 series Dimmer](https://inovelli.com/products/z-wave-black-series-smart-dimmer-switch)
+    * [LZW30-SN Red 500 Series Switch](https://help.inovelli.com/en/articles/8453781-red-series-on-off-switch-manual)
+    * [LZW31-SN Red 500 Series Dimmer](https://help.inovelli.com/en/articles/8319390-red-series-dimmer-switch-manual)
+    * [LZW36 Red 500 Series Fan / Light Combo](https://help.inovelli.com/en/articles/8483467-red-series-fan-light-switch-manual)
+    * [VZW31-SN Red 800 Series 2-in-1 Dimmer](https://inovelli.com/products/z-wave-800-red-series-smart-2-1-on-off-dimmer-switch)
   * Zigbee:
-    * [VZM31-SN Blue Series (Zigbee) 2-in-1 dimmer](https://inovelli.com/en-ca/products/zigbee-matter-blue-series-smart-2-1-on-off-dimmer-switch)
-    * [Inovelli Fan Controller (VZM35-SN)](https://inovelli.com/products/blue-series-fan-switch-zigbee-3-0)
+    * [VZM31-SN Blue Series 2-in-1 Dimmer](https://inovelli.com/en-ca/products/zigbee-matter-blue-series-smart-2-1-on-off-dimmer-switch)
+    * [VZM35-SN Blue Series 3-Speed Fan Switch](https://inovelli.com/products/blue-series-fan-switch-zigbee-3-0)
   
   
     

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -42,7 +42,7 @@ fields:
             model: LZW30, LZW31, LZW30-SN, LZW31-SN, LZW36, VZW31-SN 
           - integration: mqtt
             manufacturer: Inovelli
-            model: Inovelli 2-in-1 switch + dimmer (VZM31-SN)
+            model: Inovelli 2-in-1 switch + dimmer (VZM31-SN), Inovelli Fan Controller (VZM35-SN)
 
   group:
     name: Group
@@ -93,6 +93,9 @@ fields:
           - integration: mqtt
             manufacturer: Inovelli
             model: Inovelli 2-in-1 switch + dimmer (VZM31-SN)
+          - integration: mqtt
+            manufacturer: Inovelli
+            model: Inovelli Fan Controller (VZM35-SN)
 
   entity:
     name: Entity
@@ -552,6 +555,29 @@ variables:
     siren slow: 19
     siren fast: 18
     solid: 1
+    
+  ### Blue Series Fan ###
+  VZM35SN_effects:
+    "off": 0
+    aurora: 8
+    blink fast: 2
+    blink medium: 15
+    blink slow: 3
+    chase slow: 16
+    chase: 5
+    chase fast: 17
+    fall slow: 9
+    fall medium: 10
+    fall fast: 11
+    open close: 6
+    pulse: 4
+    rise slow: 12
+    rise medium: 13
+    rise fast: 14
+    small to big: 7
+    siren slow: 19
+    siren fast: 18
+    solid: 1
 
   ##################
   # Store model names for RED and BLUE versions for reference and validation checks if necessary
@@ -565,7 +591,8 @@ variables:
     - VZW31-SN # Red 800 series dimmer
 
   zigbee_models: # BLUE
-    - Inovelli 2-in-1 switch + dimmer (VZM31-SN) # blue_dimmer_switch
+    - Inovelli 2-in-1 switch + dimmer (VZM31-SN) # Blue Series dimmer
+    - Inovelli Fan Controller (VZM35-SN)         # Blue Series fan
 
   ##################
   # Allowed domains to limit which types of entities are processed
@@ -880,6 +907,17 @@ sequence:
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
               {% if is_device_attr(ent,'model','Inovelli 2-in-1 switch + dimmer (VZM31-SN)') and ent.split('.')[0] == 'light' %}
+                {% set entities.entities = entities.entities + [ent] %}
+              {% endif %}
+            {% endfor %}
+            {{ entities.entities }}
+            
+        - device_type: VZM35SN
+          call_type: z2m
+          entities: >-
+            {% set entities = namespace(entities=[]) %}
+            {% for ent in all_selected_entities %}
+              {% if is_device_attr(ent,'model','Inovelli Fan Controller (VZM35-SN)') and ent.split('.')[0] == 'fan' %}
                 {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -350,7 +350,30 @@ variables:
     forever: 255
     indefinitely: 255
 
-  ### Red Series Switch ###
+  ### Black 500 Series Dimmer ###
+  VZW31SN_effects:
+    "off": 0
+    aurora: 0
+    blink fast: 0
+    blink medium: 0
+    blink slow: 0
+    chase slow: 0
+    chase: 0
+    chase fast: 0
+    fall slow: 0
+    fall medium: 0
+    fall fast: 0
+    open close: 0
+    pulse: 0
+    rise slow: 0
+    rise medium: 0
+    rise fast: 0
+    small to big: 0
+    siren slow: 0
+    siren fast: 0
+    solid: 0
+    
+  ### Red 500 Series Switch ###
   LZW30SN_effects:
     "off": 0
     solid: 1
@@ -376,7 +399,7 @@ variables:
     siren slow: 4
     siren fast: 4
 
-  ### Red Series Dimmer ###
+  ### Red 500 Series Dimmer ###
   LZW31SN_effects:
     "off": 0
     solid: 1
@@ -402,7 +425,7 @@ variables:
     siren slow: 5
     siren fast: 5
 
-  ### Red Series Fan Light Combo ###
+  ### Red 500 Series Fan Light Combo ###
   LZW36_light_effects:
     "off": 0
     solid: 1
@@ -502,11 +525,13 @@ variables:
   ##################
   # Store model names for RED and BLUE versions for reference and validation checks if necessary
   ##################
-  zwave_models: # RED
-    - LZW31-SN # dimmer
-    - LZW30-SN # switch
-    - LZW36 # combo_light, combo_fan
-    - VZW31-SN # 800 series dimmer
+  zwave_models:
+    - LZW30    # Black 500 Series switch
+    - LZW31    # Black 500 Series dimmer
+    - LZW31-SN # Red 500 Series dimmer
+    - LZW30-SN # Red 500 Series switch
+    - LZW36    # Red 500 Series combo_light, combo_fan
+    - VZW31-SN # Red 800 series dimmer
 
   zigbee_models: # BLUE
     - Inovelli 2-in-1 switch + dimmer (VZM31-SN) # blue_dimmer_switch
@@ -523,6 +548,24 @@ variables:
 # There's a lot of redundancy here, but it should be easy to update if parameter names change for one model and not another
 ##################
   parameters:
+    LZW30_effect_bulk: "null"
+    LZW30_effect_color: "null"
+    LZW30_effect_brightness: "null"
+    LZW30_effect_duration: "null"
+    LZW30_effect_effect: "null"
+    LZW30_ledcolor: "LED Indicator Color"
+    LZW30_ledbrightness: "LED Indicator Intensity (When on)"
+    LZW30_ledbrightness_off: "LED Indicator Intensity (When Off)"
+    
+    LZW31_effect_bulk: "null"
+    LZW31_effect_color: "null"
+    LZW31_effect_brightness: "null"
+    LZW31_effect_duration: "null"
+    LZW31_effect_effect: "null"
+    LZW31_ledcolor: "LED Indicator Color"
+    LZW31_ledbrightness: "LED Indicator Intensity"
+    LZW31_ledbrightness_off: "LED Indicator Intensity (When Off)"
+  
     LZW31SN_effect_bulk: 16
     LZW31SN_effect_color: "LED Indicator: Effect Color"
     LZW31SN_effect_brightness: "LED Indicator: Effect Brightness"
@@ -717,12 +760,23 @@ sequence:
   ##################
   - repeat:
       for_each:
-        - device_type: LZW31SN
+        - device_type: LZW30
           call_type: zwave_js
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,'model','LZW31-SN') and ent.split('.')[0] == 'light' %}
+              {% if is_device_attr(ent,'model','LZW30') and ent.split('.')[0] == 'switch' %}
+                {% set entities.entities = entities.entities + [ent] %}
+              {% endif %}
+            {% endfor %}
+            {{ entities.entities }}
+
+        - device_type: LZW31
+          call_type: zwave_js
+          entities: >-
+            {% set entities = namespace(entities=[]) %}
+            {% for ent in all_selected_entities %}
+              {% if is_device_attr(ent,'model','LZW31') and ent.split('.')[0] == 'light' %}
                 {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
@@ -734,6 +788,17 @@ sequence:
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
               {% if is_device_attr(ent,'model','LZW30-SN') and ent.split('.')[0] == 'switch' %}
+                {% set entities.entities = entities.entities + [ent] %}
+              {% endif %}
+            {% endfor %}
+            {{ entities.entities }}
+
+        - device_type: LZW31SN
+          call_type: zwave_js
+          entities: >-
+            {% set entities = namespace(entities=[]) %}
+            {% for ent in all_selected_entities %}
+              {% if is_device_attr(ent,'model','LZW31-SN') and ent.split('.')[0] == 'light' %}
                 {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
@@ -920,7 +985,8 @@ sequence:
         ##################
         - choose:
             - conditions: >-
-                {{ effect != "off" and  color != "no change" and  duration != "invalid" and  brightness != 11 }}
+                {{ effect != "off" and  color != "no change" and  duration != "invalid" and brightness != 11 and 
+                   repeat.item.device_type != 'LZW30' and repeat.item.device_type != 'LZW31' }}
               sequence:
                 - choose:
                     - conditions: "{{ repeat.item.call_type == 'zwave_js' }}"
@@ -966,7 +1032,7 @@ sequence:
             # It's also a safer way to fail since the worst case scenario is that an effect is cleared.
             ##################
             - choose:
-                - conditions: "{{ repeat.item.call_type == 'zwave_js' }}"
+                - conditions: "{{ repeat.item.call_type == 'zwave_js' and repeat.item.device_type != 'LZW30' and repeat.item.device_type != 'LZW31' }}"
                   sequence:
                     # Zwave JS
                     - service: zwave_js.set_config_parameter

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -39,7 +39,7 @@ fields:
         device:
           - integration: zwave_js
             manufacturer: Inovelli
-            model: LZW36, LZW30-SN, LZW31-SN, VZW31-SN
+            model: LZW36, LZW30-SN, LZW31-SN, VZW31-SN, LZW30, LZW31
           - integration: mqtt
             manufacturer: Inovelli
             model: Inovelli 2-in-1 switch + dimmer (VZM31-SN)
@@ -81,6 +81,12 @@ fields:
           - integration: zwave_js
             manufacturer: Inovelli
             model: LZW31-SN
+          - integration: zwave_js
+            manufacturer: Inovelli
+            model: LZW30
+          - integration: zwave_js
+            manufacturer: Inovelli
+            model: LZW31
           - integration: zwave_js
             manufacturer: Inovelli
             model: VZW31-SN

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -30,7 +30,7 @@ fields:
   area:
     name: Area
     description: Area names or IDs containing Inovelli LZW30, LZW31, LZW30-SN, LZW31-SN,
-      LZW36, VZW31-SN, VZM31-SN, VZM35 devices.  Mix and match types as you like.
+      LZW36, VZW31-SN, VZM31-SN, VZM35-SN devices.  Mix and match types as you like.
     required: false
     example: 'Family Room, 7d7a44fe4d0f4bee947c430d2714e45c'
     selector:
@@ -48,7 +48,7 @@ fields:
     name: Group
     description: >-
       Group names or IDs for groups containing Inovelli LZW30, LZW31, LZW30-SN, LZW31-SN,
-      LZW36, VZW31-SN, VZM31-SN, VZM35 devices.  Mix and match types as you like.
+      LZW36, VZW31-SN, VZM31-SN, VZM35-SN devices.  Mix and match types as you like.
     required: false
     example: 'group.lights_and_switches, 0249abdc634c12cbf6cdc06d7a507495'
     selector:
@@ -65,7 +65,7 @@ fields:
     name: Device
     description: >-
       Device IDs for Inovelli LZW30, LZW31, LZW30-SN, LZW31-SN,
-      LZW36, VZW31-SN, VZM31-SN, VZM35 devices.  Mix and match types as you like.
+      LZW36, VZW31-SN, VZM31-SN, VZM35-SN devices.  Mix and match types as you like.
     required: false
     example: '0249abdc634c12cbf6cdc06d7a507495'
     selector:
@@ -95,14 +95,14 @@ fields:
             model: Inovelli 2-in-1 switch + dimmer (VZM31-SN)
           - integration: mqtt
             manufacturer: Inovelli
-            model: Inovelli Fan Controller (VZM35)
+            model: Inovelli Fan Controller (VZM35-SN)
 
   entity:
     name: Entity
     description: >-
       The light.*, switch.*, or fan.* entity for the LED we're setting.  Can be
       a comma separated list of Inovelli LZW30, LZW31, LZW30-SN, LZW31-SN,
-      LZW36, VZW31-SN, VZM31-SN, VZM35 devices.  Mix and match types as you like.
+      LZW36, VZW31-SN, VZM31-SN, VZM35-SN devices.  Mix and match types as you like.
     required: false
     example: light.office, fan.guest_room
     selector:
@@ -554,23 +554,23 @@ variables:
     "off": 0
     aurora: 8
     blink: 15
-    blink fast: 2
+    blink fast: 3
     blink medium: 15
-    blink slow: 3
+    blink slow: 4
     chase: 5
     chase fast: 17
-    chase medium: 5
+    chase medium: 2
     chase slow: 16
     fall fast: 11
     fall medium: 10
     fall slow: 9
     open close: 6
-    pulse: 4
+    pulse: 5
     rise fast: 14
     rise medium: 13
     rise slow: 12
-    siren fast: 18
-    siren slow: 19
+    siren fast: 17
+    siren slow: 16
     small to big: 7
     solid: 1
     fast blink: 2
@@ -596,8 +596,8 @@ variables:
     rise fast: 14
     rise medium: 13
     rise slow: 12
-    siren fast: 18
-    siren slow: 19
+    siren fast: 19
+    siren slow: 18
     small to big: 7
     solid: 1
     fast blink: 2

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -29,7 +29,8 @@ fields:
 
   area:
     name: Area
-    description: Area names or IDs containing Inovelli devices.
+    description: Area names or IDs containing Inovelli LZW36, LZW30-SN, LZW31-SN,
+      VZW31-SN, LZW30, or LZW31 devices.  Mix and match types as you like.
     required: false
     example: 'Family Room, 7d7a44fe4d0f4bee947c430d2714e45c'
     selector:
@@ -47,7 +48,7 @@ fields:
     name: Group
     description: >-
       Group names or IDs for groups containing Inovelli LZW36, LZW30-SN, LZW31-SN,
-      VZW31-SN devices.  Mix and match types as you like.
+      VZW31-SN, LZW30, or LZW31 devices.  Mix and match types as you like.
     required: false
     example: 'group.lights_and_switches, 0249abdc634c12cbf6cdc06d7a507495'
     selector:
@@ -63,8 +64,8 @@ fields:
   device:
     name: Device
     description: >-
-      Device IDs for Inovelli LZW36, LZW30-SN, LZW31-SN, VZM31-SN, VZW31-SN
-      device IDs.  Mix and match types as you like.
+      Device IDs for Inovelli LZW36, LZW30-SN, LZW31-SN,
+      VZW31-SN, LZW30, or LZW31 devices.  Mix and match types as you like.
     required: false
     example: '0249abdc634c12cbf6cdc06d7a507495'
     selector:
@@ -91,7 +92,8 @@ fields:
     name: Entity
     description: >-
       The light.*, switch.*, or fan.* entity for the LED we're setting.  Can be
-      a comma separated list. Mix and match types as you like.
+      a comma separated list of Inovelli LZW36, LZW30-SN, LZW31-SN,
+      VZW31-SN, LZW30, or LZW31 devices.  Mix and match types as you like.
     required: false
     example: light.office, fan.guest_room
     selector:

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -42,7 +42,7 @@ fields:
             model: LZW30, LZW31, LZW30-SN, LZW31-SN, LZW36, VZW31-SN 
           - integration: mqtt
             manufacturer: Inovelli
-            model: Inovelli 2-in-1 switch + dimmer (VZM31-SN), Inovelli Fan Controller (VZM35-SN)
+            model: Inovelli 2-in-1 switch + dimmer (VZM31-SN) ###, Inovelli Fan Controller (VZM35-SN)
 
   group:
     name: Group
@@ -557,27 +557,28 @@ variables:
     solid: 1
     
   ### Blue Series Fan ###
-  VZM35SN_effects:
-    "off": 0
-    aurora: 8
-    blink fast: 2
-    blink medium: 15
-    blink slow: 3
-    chase slow: 16
-    chase: 5
-    chase fast: 17
-    fall slow: 9
-    fall medium: 10
-    fall fast: 11
-    open close: 6
-    pulse: 4
-    rise slow: 12
-    rise medium: 13
-    rise fast: 14
-    small to big: 7
-    siren slow: 19
-    siren fast: 18
-    solid: 1
+  ### Same as Blue Dimmer? ###
+  #VZM35SN_effects:
+  #  "off": 0
+  #  aurora: 8
+  #  blink fast: 2
+  #  blink medium: 15
+  #  blink slow: 3
+  #  chase slow: 16
+  #  chase: 5
+  #  chase fast: 17
+  #  fall slow: 9
+  #  fall medium: 10
+  #  fall fast: 11
+  #  open close: 6
+  #  pulse: 4
+  #  rise slow: 12
+  #  rise medium: 13
+  #  rise fast: 14
+  #  small to big: 7
+  #  siren slow: 19
+  #  siren fast: 18
+  #  solid: 1
 
   ##################
   # Store model names for RED and BLUE versions for reference and validation checks if necessary
@@ -592,7 +593,7 @@ variables:
 
   zigbee_models: # BLUE
     - Inovelli 2-in-1 switch + dimmer (VZM31-SN) # Blue Series dimmer
-    - Inovelli Fan Controller (VZM35-SN)         # Blue Series fan
+    #- Inovelli Fan Controller (VZM35-SN)         # Blue Series fan
 
   ##################
   # Allowed domains to limit which types of entities are processed

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -17,7 +17,7 @@ alias: Inovelli LED Settings and Effects
 #   color: (string) Sets color of LED effect and must be one of: Off, Red, Orange, Yellow, Green, Cyan, Teal, Blue, Purple, Light Pink, Pink, White
 #
 # Effects not working?  Check that your device supports the effect you're selecting at https://inovelliusa.github.io/inovelli-switch-toolbox/
-#   Effects that are not supported on a specific device are remapped to a supported effect.  
+#   Effects that are not supported on a specific device are remapped to a supported effect.  Black 500 Series devices do not support effects.
 ############
 description: >-
   Handles setting the LED colors and notifications on Inovelli "Red" and "Blue"

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -761,7 +761,7 @@ sequence:
             {% endfor %}
             {{ entities.entities }}
 
-        - device_type: blue_dimmer_switch
+        - device_type: VZM31SN
           call_type: z2m
           entities: >-
             {% set entities = namespace(entities=[]) %}

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -359,7 +359,7 @@ variables:
     indefinitely: 255
 
   ### Black 500 Series Dimmer ###
-  VZW31SN_effects:
+  LZW30_effects:
     "off": 0
     aurora: 0
     blink fast: 0
@@ -380,7 +380,30 @@ variables:
     siren slow: 0
     siren fast: 0
     solid: 0
-    
+
+  ### Black 500 Series Dimmer ###
+  LZW31_effects:
+    "off": 0
+    aurora: 0
+    blink fast: 0
+    blink medium: 0
+    blink slow: 0
+    chase slow: 0
+    chase: 0
+    chase fast: 0
+    fall slow: 0
+    fall medium: 0
+    fall fast: 0
+    open close: 0
+    pulse: 0
+    rise slow: 0
+    rise medium: 0
+    rise fast: 0
+    small to big: 0
+    siren slow: 0
+    siren fast: 0
+    solid: 0
+   
   ### Red 500 Series Switch ###
   LZW30SN_effects:
     "off": 0

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -1082,7 +1082,7 @@ sequence:
                               {% elif repeat.item.device_type == "LZW36_fan" %}
                                 {{ color_set[color] + (brightness * 256) + (duration_values[duration] * 65536) + (LZW36_fan_effects[effect] * 16777216) }}
                               {% elif repeat.item.device_type == "VZW31SN" %}
-                                {{ (color_set[color] * 65536) + (brightness*10 * 256) + (duration_values[duration]) + (VZW31SN_effects[effect] * 16777216) }}
+                                {{ (color_set[color] * 65536) + (brightness * 10 * 256) + (duration_values[duration]) + (VZW31SN_effects[effect] * 16777216) }}
                               {% endif %}
                 - choose:
                     - conditions: "{{ repeat.item.call_type == 'z2m' }}"

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -30,7 +30,7 @@ fields:
   area:
     name: Area
     description: Area names or IDs containing Inovelli LZW30, LZW31, LZW30-SN, LZW31-SN,
-      LZW36, or VZW31-SN devices.  Mix and match types as you like.
+      LZW36, VZW31-SN, VZM31-SN, VZM35 devices.  Mix and match types as you like.
     required: false
     example: 'Family Room, 7d7a44fe4d0f4bee947c430d2714e45c'
     selector:
@@ -42,13 +42,13 @@ fields:
             model: LZW30, LZW31, LZW30-SN, LZW31-SN, LZW36, VZW31-SN 
           - integration: mqtt
             manufacturer: Inovelli
-            model: Inovelli 2-in-1 switch + dimmer (VZM31-SN) ###, Inovelli Fan Controller (VZM35-SN)
+            model: Inovelli 2-in-1 switch + dimmer (VZM31-SN), Inovelli Fan Controller (VZM35-SN)
 
   group:
     name: Group
     description: >-
       Group names or IDs for groups containing Inovelli LZW30, LZW31, LZW30-SN, LZW31-SN,
-      LZW36, or VZW31-SN devices.  Mix and match types as you like.
+      LZW36, VZW31-SN, VZM31-SN, VZM35 devices.  Mix and match types as you like.
     required: false
     example: 'group.lights_and_switches, 0249abdc634c12cbf6cdc06d7a507495'
     selector:
@@ -65,7 +65,7 @@ fields:
     name: Device
     description: >-
       Device IDs for Inovelli LZW30, LZW31, LZW30-SN, LZW31-SN,
-      LZW36, or VZW31-SN devices.  Mix and match types as you like.
+      LZW36, VZW31-SN, VZM31-SN, VZM35 devices.  Mix and match types as you like.
     required: false
     example: '0249abdc634c12cbf6cdc06d7a507495'
     selector:
@@ -95,14 +95,14 @@ fields:
             model: Inovelli 2-in-1 switch + dimmer (VZM31-SN)
           - integration: mqtt
             manufacturer: Inovelli
-            model: Inovelli Fan Controller (VZM35-SN)
+            model: Inovelli Fan Controller (VZM35)
 
   entity:
     name: Entity
     description: >-
       The light.*, switch.*, or fan.* entity for the LED we're setting.  Can be
       a comma separated list of Inovelli LZW30, LZW31, LZW30-SN, LZW31-SN,
-      LZW36, or VZW31-SN devices.  Mix and match types as you like.
+      LZW36, VZW31-SN, VZM31-SN, VZM35 devices.  Mix and match types as you like.
     required: false
     example: light.office, fan.guest_room
     selector:
@@ -240,22 +240,22 @@ fields:
           - "off"
           - Aurora
           - Blink Fast
-          - Blink medium
+          - Blink Medium
           - Blink Slow
-          - Chase Slow
-          - Chase
           - Chase Fast
-          - Fall Slow
-          - Fall Medium
+          - Chase Medium
+          - Chase Slow
           - Fall Fast
+          - Fall Medium
+          - Fall Slow
           - Open Close
           - Pulse
-          - Rise Slow
-          - Rise Medium
           - Rise Fast
-          - Small to Big
-          - Siren Slow
+          - Rise Medium
+          - Rise Slow
           - Siren Fast
+          - Siren Slow
+          - Small to Big
           - Solid
 
   brightness:
@@ -365,220 +365,243 @@ variables:
   LZW30_effects:
     "off": 0
     aurora: 0
+    blink: 0
     blink fast: 0
     blink medium: 0
     blink slow: 0
-    chase slow: 0
     chase: 0
     chase fast: 0
-    fall slow: 0
-    fall medium: 0
+    chase medium: 0
+    chase slow: 0
     fall fast: 0
+    fall medium: 0
+    fall slow: 0
     open close: 0
     pulse: 0
-    rise slow: 0
-    rise medium: 0
     rise fast: 0
-    small to big: 0
-    siren slow: 0
+    rise medium: 0
+    rise slow: 0
     siren fast: 0
+    siren slow: 0
+    small to big: 0
     solid: 0
+    fast blink: 0
+    slow blink: 0
 
   ### Black 500 Series Dimmer ###
   LZW31_effects:
     "off": 0
     aurora: 0
+    blink: 0
     blink fast: 0
     blink medium: 0
     blink slow: 0
-    chase slow: 0
     chase: 0
     chase fast: 0
-    fall slow: 0
-    fall medium: 0
+    chase medium: 0
+    chase slow: 0
     fall fast: 0
+    fall medium: 0
+    fall slow: 0
     open close: 0
     pulse: 0
-    rise slow: 0
-    rise medium: 0
     rise fast: 0
-    small to big: 0
-    siren slow: 0
+    rise medium: 0
+    rise slow: 0
     siren fast: 0
+    siren slow: 0
+    small to big: 0
     solid: 0
+    fast blink: 0
+    slow blink: 0
    
   ### Red 500 Series Switch ###
   LZW30SN_effects:
     "off": 0
-    solid: 1
-    fast blink: 2
-    chase: 2
-    slow blink: 3
-    blink: 3
-    pulse: 4
     aurora: 4
+    blink: 3
     blink fast: 2
     blink medium: 3
     blink slow: 3
-    chase slow: 3
+    chase: 2
     chase fast: 2
-    fall slow: 3
-    fall medium: 3
+    chase medium: 2
+    chase slow: 3
     fall fast: 2
+    fall medium: 3
+    fall slow: 3
     open close: 4
-    rise slow: 3
-    rise medium: 3
+    pulse: 4
     rise fast: 2
-    small to big: 4
-    siren slow: 4
+    rise medium: 3
+    rise slow: 3
     siren fast: 4
+    siren slow: 4
+    small to big: 4
+    solid: 1
+    fast blink: 2
+    slow blink: 3
 
   ### Red 500 Series Dimmer ###
   LZW31SN_effects:
     "off": 0
-    solid: 1
-    chase: 2
-    fast blink: 3
-    slow blink: 4
+    aurora: 4
     blink: 4
-    pulse: 5
-    aurora: 2
     blink fast: 3
     blink medium: 4
     blink slow: 4
-    chase slow: 2
+    chase: 2
     chase fast: 2
-    fall slow: 2
-    fall medium: 2
+    chase medium: 2
+    chase slow: 2
     fall fast: 2
-    open close: 5
-    rise slow: 2
-    rise medium: 2
+    fall medium: 2
+    fall slow: 2
+    open close: 2
+    pulse: 5
     rise fast: 2
-    small to big: 5
-    siren slow: 5
-    siren fast: 5
+    rise medium: 2
+    rise slow: 2
+    siren slow: 2
+    siren fast: 2
+    small to big: 2
+    solid: 1
+    fast blink: 3
+    slow blink: 4
 
   ### Red 500 Series Fan Light Combo ###
   LZW36_light_effects:
     "off": 0
-    solid: 1
-    chase: 2
-    fast blink: 3
-    slow blink: 4
+    aurora: 4
     blink: 4
-    pulse: 5
-    aurora: 2
     blink fast: 3
     blink medium: 4
     blink slow: 4
-    chase slow: 2
+    chase: 2
     chase fast: 2
-    fall slow: 2
-    fall medium: 2
+    chase medium: 2
+    chase slow: 2
     fall fast: 2
-    open close: 5
-    rise slow: 2
-    rise medium: 2
+    fall medium: 2
+    fall slow: 2
+    open close: 2
+    pulse: 5
     rise fast: 2
-    small to big: 5
-    siren slow: 5
-    siren fast: 5
+    rise medium: 2
+    rise slow: 2
+    siren slow: 2
+    siren fast: 2
+    small to big: 2
+    solid: 1
+    fast blink: 3
+    slow blink: 4
 
   LZW36_fan_effects:
     "off": 0
-    solid: 1
-    chase: 2
-    fast blink: 3
-    slow blink: 4
+    aurora: 4
     blink: 4
-    pulse: 5
-    aurora: 2
     blink fast: 3
     blink medium: 4
     blink slow: 4
-    chase slow: 2
+    chase: 2
     chase fast: 2
-    fall slow: 2
-    fall medium: 2
+    chase medium: 2
+    chase slow: 2
     fall fast: 2
-    open close: 5
-    rise slow: 2
-    rise medium: 2
+    fall medium: 2
+    fall slow: 2
+    open close: 2
+    pulse: 5
     rise fast: 2
-    small to big: 5
-    siren slow: 5
-    siren fast: 5
+    rise medium: 2
+    rise slow: 2
+    siren slow: 2
+    siren fast: 2
+    small to big: 2
+    solid: 1
+    fast blink: 3
+    slow blink: 4
 
   ### Red 800 Series Dimmer ###
   VZW31SN_effects:
     "off": 0
     aurora: 8
+    blink: 15
     blink fast: 2
     blink medium: 15
     blink slow: 3
-    chase slow: 16
     chase: 5
     chase fast: 17
-    fall slow: 9
-    fall medium: 10
+    chase medium: 5
+    chase slow: 16
     fall fast: 11
+    fall medium: 10
+    fall slow: 9
     open close: 6
     pulse: 4
-    rise slow: 12
-    rise medium: 13
     rise fast: 14
-    small to big: 7
-    siren slow: 19
+    rise medium: 13
+    rise slow: 12
     siren fast: 18
+    siren slow: 19
+    small to big: 7
     solid: 1
+    fast blink: 2
+    slow blink: 3
 
   ### Blue Series Dimmer ###
   VZM31SN_effects:
     "off": 0
     aurora: 8
+    blink: 15
     blink fast: 2
     blink medium: 15
     blink slow: 3
-    chase slow: 16
     chase: 5
     chase fast: 17
-    fall slow: 9
-    fall medium: 10
+    chase medium: 5
+    chase slow: 16
     fall fast: 11
+    fall medium: 10
+    fall slow: 9
     open close: 6
     pulse: 4
-    rise slow: 12
-    rise medium: 13
     rise fast: 14
-    small to big: 7
-    siren slow: 19
+    rise medium: 13
+    rise slow: 12
     siren fast: 18
+    siren slow: 19
+    small to big: 7
     solid: 1
+    fast blink: 2
+    slow blink: 3
     
   ### Blue Series Fan ###
-  ### Same as Blue Dimmer? ###
-  #VZM35SN_effects:
-  #  "off": 0
-  #  aurora: 8
-  #  blink fast: 2
-  #  blink medium: 15
-  #  blink slow: 3
-  #  chase slow: 16
-  #  chase: 5
-  #  chase fast: 17
-  #  fall slow: 9
-  #  fall medium: 10
-  #  fall fast: 11
-  #  open close: 6
-  #  pulse: 4
-  #  rise slow: 12
-  #  rise medium: 13
-  #  rise fast: 14
-  #  small to big: 7
-  #  siren slow: 19
-  #  siren fast: 18
-  #  solid: 1
+  VZM35SN_effects:
+    "off": 0
+    aurora: 8
+    blink: 15
+    blink fast: 2
+    blink medium: 15
+    blink slow: 3
+    chase: 5
+    chase fast: 17
+    chase medium: 5
+    chase slow: 16
+    fall fast: 11
+    fall medium: 10
+    fall slow: 9
+    open close: 6
+    pulse: 4
+    rise fast: 14
+    rise medium: 13
+    rise slow: 12
+    siren fast: 18
+    siren slow: 19
+    small to big: 7
+    solid: 1
+    fast blink: 2
+    slow blink: 3
 
   ##################
   # Store model names for RED and BLUE versions for reference and validation checks if necessary
@@ -593,7 +616,7 @@ variables:
 
   zigbee_models: # BLUE
     - Inovelli 2-in-1 switch + dimmer (VZM31-SN) # Blue Series dimmer
-    #- Inovelli Fan Controller (VZM35-SN)         # Blue Series fan
+    - Inovelli Fan Controller (VZM35-SN)         # Blue Series fan
 
   ##################
   # Allowed domains to limit which types of entities are processed

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -791,6 +791,9 @@ sequence:
   ##################
   - repeat:
       for_each:
+          ##################
+          # Z-Wave
+          ##################          
         - device_type: LZW30
           call_type: zwave_js
           entities: >-
@@ -856,18 +859,7 @@ sequence:
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
-
-        - device_type: VZM31SN
-          call_type: z2m
-          entities: >-
-            {% set entities = namespace(entities=[]) %}
-            {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,'model','Inovelli 2-in-1 switch + dimmer (VZM31-SN)') and ent.split('.')[0] == 'light' %}
-                {% set entities.entities = entities.entities + [ent] %}
-              {% endif %}
-            {% endfor %}
-            {{ entities.entities }}
-
+            
         - device_type: VZW31SN
           call_type: zwave_js
           entities: >-
@@ -879,8 +871,21 @@ sequence:
             {% endfor %}
             {{ entities.entities }}
 
-      sequence:
+          ##################
+          # Zigbee
+          ##################
+        - device_type: VZM31SN
+          call_type: z2m
+          entities: >-
+            {% set entities = namespace(entities=[]) %}
+            {% for ent in all_selected_entities %}
+              {% if is_device_attr(ent,'model','Inovelli 2-in-1 switch + dimmer (VZM31-SN)') and ent.split('.')[0] == 'light' %}
+                {% set entities.entities = entities.entities + [ent] %}
+              {% endif %}
+            {% endfor %}
+            {{ entities.entities }}
 
+      sequence:
         ##################
         # Do not continue if we don't have at least one entity of this type
         ##################

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -29,8 +29,8 @@ fields:
 
   area:
     name: Area
-    description: Area names or IDs containing Inovelli LZW36, LZW30-SN, LZW31-SN,
-      VZW31-SN, LZW30, or LZW31 devices.  Mix and match types as you like.
+    description: Area names or IDs containing Inovelli LZW30, LZW31, LZW30-SN, LZW31-SN,
+      LZW36, or VZW31-SN devices.  Mix and match types as you like.
     required: false
     example: 'Family Room, 7d7a44fe4d0f4bee947c430d2714e45c'
     selector:
@@ -39,7 +39,7 @@ fields:
         device:
           - integration: zwave_js
             manufacturer: Inovelli
-            model: LZW36, LZW30-SN, LZW31-SN, VZW31-SN, LZW30, LZW31
+            model: LZW30, LZW31, LZW30-SN, LZW31-SN, LZW36, VZW31-SN 
           - integration: mqtt
             manufacturer: Inovelli
             model: Inovelli 2-in-1 switch + dimmer (VZM31-SN)
@@ -47,8 +47,8 @@ fields:
   group:
     name: Group
     description: >-
-      Group names or IDs for groups containing Inovelli LZW36, LZW30-SN, LZW31-SN,
-      VZW31-SN, LZW30, or LZW31 devices.  Mix and match types as you like.
+      Group names or IDs for groups containing Inovelli LZW30, LZW31, LZW30-SN, LZW31-SN,
+      LZW36, or VZW31-SN devices.  Mix and match types as you like.
     required: false
     example: 'group.lights_and_switches, 0249abdc634c12cbf6cdc06d7a507495'
     selector:
@@ -64,8 +64,8 @@ fields:
   device:
     name: Device
     description: >-
-      Device IDs for Inovelli LZW36, LZW30-SN, LZW31-SN,
-      VZW31-SN, LZW30, or LZW31 devices.  Mix and match types as you like.
+      Device IDs for Inovelli LZW30, LZW31, LZW30-SN, LZW31-SN,
+      LZW36, or VZW31-SN devices.  Mix and match types as you like.
     required: false
     example: '0249abdc634c12cbf6cdc06d7a507495'
     selector:
@@ -74,7 +74,10 @@ fields:
         filter:
           - integration: zwave_js
             manufacturer: Inovelli
-            model: LZW36
+            model: LZW30
+          - integration: zwave_js
+            manufacturer: Inovelli
+            model: LZW31
           - integration: zwave_js
             manufacturer: Inovelli
             model: LZW30-SN
@@ -83,10 +86,7 @@ fields:
             model: LZW31-SN
           - integration: zwave_js
             manufacturer: Inovelli
-            model: LZW30
-          - integration: zwave_js
-            manufacturer: Inovelli
-            model: LZW31
+            model: LZW36
           - integration: zwave_js
             manufacturer: Inovelli
             model: VZW31-SN
@@ -98,8 +98,8 @@ fields:
     name: Entity
     description: >-
       The light.*, switch.*, or fan.* entity for the LED we're setting.  Can be
-      a comma separated list of Inovelli LZW36, LZW30-SN, LZW31-SN,
-      VZW31-SN, LZW30, or LZW31 devices.  Mix and match types as you like.
+      a comma separated list of Inovelli LZW30, LZW31, LZW30-SN, LZW31-SN,
+      LZW36, or VZW31-SN devices.  Mix and match types as you like.
     required: false
     example: light.office, fan.guest_room
     selector:


### PR DESCRIPTION
Readme:
- Added links to device pages (or manuals, where the device page has gone missing)

Script:
- All effects are mapped to each device.  Where older devices don't support a new effect, that effect has been mapped to something else.  Users will still get _something_ and the script shouldn't generate errors in the logs.
- Using model names for service calls instead of device series and type so it's easier to debug.
- Effect calls block Black 500 Series devices (which don't support effects)
- Cleaned up selector filters.