### PR TITLE
Z2 m "off"  > "clear effect"

### DIFF
--- a/blueprints/script/kschlichter/inovelli_led_blueprint.yaml
+++ b/blueprints/script/kschlichter/inovelli_led_blueprint.yaml
@@ -1366,7 +1366,7 @@ sequence:
                             data:
                               topic: >-
                                 zigbee2mqtt/{{ states[repeat.item].attributes.friendly_name }}/set
-                              payload: "{\"led_effect\":{\"duration\":\"1\",\"effect\":\"clear\"}}"
+                              payload: "{\"led_effect\":{\"duration\":\"1\",\"effect\":\"clear_effect\"}}"
             - choose:
                 - conditions: "{{ repeat.item.call_type == 'zha' }}"
                   sequence:

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -1366,7 +1366,7 @@ sequence:
                             data:
                               topic: >-
                                 zigbee2mqtt/{{ states[repeat.item].attributes.friendly_name }}/set
-                              payload: "{\"led_effect\":{\"duration\":\"1\",\"effect\":\"clear\"}}"
+                              payload: "{\"led_effect\":{\"duration\":\"1\",\"effect\":\"clear_effect\"}}"
             - choose:
                 - conditions: "{{ repeat.item.call_type == 'zha' }}"
                   sequence:


### PR DESCRIPTION
Z2M should have always been "clear_effect" and not simply "clear" as far as I can tell from the device documentation.  