### PR TITLE
fix: add `model_id` for zigbee2mqtt device lookup

### DIFF
--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -1315,7 +1315,7 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if '2-in-1 switch' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('mqtt') %}
+              {% if ('2-in-1 switch' in device_attr(ent,'model') or is_device_attr(ent,'model_id','VZM31-SN')) and ent.split('.')[0] == 'light' and ent in integration_entities('mqtt') %}
                 {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
@@ -1327,7 +1327,7 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'fan controller' in (device_attr(ent,'model')|lower) and ent.split('.')[0] == 'fan' and ent in integration_entities('mqtt') %}
+              {% if ('fan controller' in (device_attr(ent,'model')|lower) or is_device_attr(ent,'model_id','VZM35-SN')) and ent.split('.')[0] == 'fan' and ent in integration_entities('mqtt') %}
                 {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}


### PR DESCRIPTION
Add condition to check for the entity's `model_id` for zigbee2mqtt devices