### PR TITLE
Handling devices without model

### DIFF
--- a/blueprints/script/kschlichter/inovelli_led_blueprint.yaml
+++ b/blueprints/script/kschlichter/inovelli_led_blueprint.yaml
@@ -1122,7 +1122,7 @@ variables:
       {% for floor in floor_array.floor_list %}
         {% for area in floor_areas(floor) %}
           {% for ent in area_entities(area) %}
-            {% if ent.split('.')[0] in allowed_domains %}
+            {% if ent.split('.')[0] in allowed_domains and is_device_attr(ent,"manufacturer","Inovelli") %}
               {% set entities.entities = entities.entities + [ent|string|trim] %}
             {% endif %}
           {% endfor %}
@@ -1164,7 +1164,7 @@ variables:
       {# Detecting entities #}
       {% for area in area_array.area_list %}
         {% for ent in area_entities(area) %}
-          {% if ent.split('.')[0] in allowed_domains %}
+          {% if ent.split('.')[0] in allowed_domains and is_device_attr(ent,"manufacturer","Inovelli") %}
             {% set entities.entities = entities.entities + [ent|string|trim] %}
           {% endif %}
         {% endfor %}
@@ -1193,7 +1193,7 @@ variables:
       {% for group in group_array.group_list %}
         {% for entity in expand(group) %}
           {% set ent = entity.entity_id %}
-          {% if ent.split('.')[0] in allowed_domains %}
+          {% if ent.split('.')[0] in allowed_domains and is_device_attr(ent,"manufacturer","Inovelli") %}
             {% set entities.entities = entities.entities + [ent|string|trim] %}
           {% endif %}
         {% endfor %}
@@ -1230,7 +1230,7 @@ variables:
       {# Detecting entities #}
       {% for device in devices.devices %}
         {% for ent in device_entities(device) %}
-          {% if ent.split('.')[0] in allowed_domains %}
+          {% if ent.split('.')[0] in allowed_domains and is_device_attr(ent,"manufacturer","Inovelli") %}
             {% set entities.entities = entities.entities + [ent|string|trim] %}
           {% endif %}
         {% endfor %}
@@ -1265,7 +1265,7 @@ variables:
 
       {# Detecting entities #}
       {% for ent in entities_array.entities %}
-        {% if ent.split('.')[0] in allowed_domains %}
+        {% if ent.split('.')[0] in allowed_domains and is_device_attr(ent,"manufacturer","Inovelli") %}
           {% set entities.entities = entities.entities + [ent|string|trim] %}
         {% endif %}
       {% endfor %}
@@ -1317,10 +1317,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if  is_device_attr(ent,'model','LZW30') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if  is_device_attr(ent,'model','LZW30') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1330,10 +1328,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if  is_device_attr(ent,'model','LZW31') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if  is_device_attr(ent,'model','LZW31') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1343,10 +1339,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if 'LZW30-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if 'LZW30-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1356,10 +1350,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if 'LZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if 'LZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1369,10 +1361,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1382,10 +1372,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zwave_js') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zwave_js') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1396,10 +1384,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if 'VZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if 'VZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1413,10 +1399,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if ('2-in-1 switch' in device_attr(ent,'model') or is_device_attr(ent,'model_id','VZM31-SN')) and ent.split('.')[0] == 'light' and ent in integration_entities('mqtt') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if ('2-in-1 switch' in device_attr(ent,'model') or is_device_attr(ent,'model_id','VZM31-SN')) and ent.split('.')[0] == 'light' and ent in integration_entities('mqtt') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1427,10 +1411,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if ('fan controller' in (device_attr(ent,'model')|lower) or is_device_attr(ent,'model_id','VZM35-SN')) and ent.split('.')[0] == 'fan' and ent in integration_entities('mqtt') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if ('fan controller' in (device_attr(ent,'model')|lower) or is_device_attr(ent,'model_id','VZM35-SN')) and ent.split('.')[0] == 'fan' and ent in integration_entities('mqtt') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1444,10 +1426,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if 'VZM31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zha') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if 'VZM31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zha') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1458,10 +1438,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if 'VZM35-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zha') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if 'VZM35-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zha') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}

--- a/blueprints/script/kschlichter/inovelli_led_blueprint.yaml
+++ b/blueprints/script/kschlichter/inovelli_led_blueprint.yaml
@@ -31,7 +31,7 @@
 # Convert to blueprint:
 #   Switch blueprint: and script alias: lines
 #   Add two spaces to lines between label: and variables: 67,495s
-#   Comment out #example/g
+#   Comment out #example:
 #   Switch input_* and script variables in all three locations
 #
 # Zigbee2MQTT devices: https://www.zigbee2mqtt.io/supported-devices/#v=Inovelli
@@ -70,7 +70,7 @@ blueprint:
       name: Label
       description: Labels on Inovelli devices and entities, or areas containing Inovelli devices.
       #required: false
-      #example/g 'christmas lights, bedrooms, fans'
+      #example: 'christmas lights, bedrooms, fans'
       #default: 'invalid'
       selector:
         label:
@@ -80,7 +80,7 @@ blueprint:
       name: Floor
       description: Floor IDs containing areas with Inovelli devices.  
       #required: false
-      #example/g 'downstairs,upstairs, outside'
+      #example: 'downstairs,upstairs, outside'
       #default: 'invalid'
       selector:
         floor:
@@ -133,7 +133,7 @@ blueprint:
       name: Area
       description: Area names or IDs containing Inovelli devices.
       #required: false
-      #example/g 'Family Room, 7d7a44fe4d0f4bee947c430d2714e45c'
+      #example: 'Family Room, 7d7a44fe4d0f4bee947c430d2714e45c'
       #default: 'invalid'
       selector:
         area:
@@ -187,7 +187,7 @@ blueprint:
       name: Group
       description: Group names or IDs for groups containing Inovelli devices.  Mix and match types as you like.
       #required: false
-      #example/g 'group.lights_and_switches, 0249abdc634c12cbf6cdc06d7a507495'
+      #example: 'group.lights_and_switches, 0249abdc634c12cbf6cdc06d7a507495'
       #default: 'invalid'
       selector:
         entity:
@@ -203,7 +203,7 @@ blueprint:
       name: Device
       description: Device IDs of Inovelli devices.  Mix and match types as you like.
       #required: false
-      #example/g '0249abdc634c12cbf6cdc06d7a507495'
+      #example: '0249abdc634c12cbf6cdc06d7a507495'
       #default: 'invalid'
       selector:
         device:
@@ -259,7 +259,7 @@ blueprint:
         The light.*, switch.*, or fan.* entity for the LED we're setting.  Can be
         a comma separated list of Inovelli devices.  Mix and match types as you like.
       #required: false
-      #example/g light.office, fan.guest_room
+      #example: light.office, fan.guest_room
       #default: 'invalid'
       selector:
         entity:
@@ -276,7 +276,7 @@ blueprint:
       description: >-
         Sets the full LED bar by default, or specific LEDs (1 – 7) starting at the bottom.
       #required: false
-      #example/g All
+      #example: All
       #default: 'all'
       selector:
         select:
@@ -294,7 +294,7 @@ blueprint:
       name: LED Color When On (non-effect)
       description: Sets the color of the LED status, which indicates brightness levels.
       #required: false
-      #example/g Blue
+      #example: Blue
       #default: 'no change'
       selector:
         select:
@@ -323,7 +323,7 @@ blueprint:
       name: LED Color When Off (non-effect). Red 800 and Blue Series only.
       description: Sets the color of the LED status, which indicates brightness levels.
       #required: false
-      #example/g Blue
+      #example: Blue
       #default: 'no change'
       selector:
         select:
@@ -352,7 +352,7 @@ blueprint:
       name: LED Brightness When On (non-effect)
       description: Sets the brightness of the LED status when on. 0 means off.
       #required: false
-      #example/g "6"
+      #example: "6"
       #default: '11'
       selector:
         number:
@@ -365,7 +365,7 @@ blueprint:
       name: LED Brightness When Off (non-effect).
       description: Sets the brightness of the LED status when off. 0 means off.
       #required: false
-      #example/g "2"
+      #example: "2"
       #default: '11'
       selector:
         number:
@@ -378,7 +378,7 @@ blueprint:
       name: Duration of Effect
       description: How long the effect will last.
       #required: false
-      #example/g "Off"
+      #example: "Off"
       #default: '0'
       selector:
         select:
@@ -425,7 +425,7 @@ blueprint:
       name: Effect
       description: Type of effect
       #required: false
-      #example/g Pulse
+      #example: Pulse
       #default: 'Clear Effect'
       selector:
         select:
@@ -456,7 +456,7 @@ blueprint:
       name: Effect Brightness
       description: Sets the brightness of the LED's effect.  0 means off.
       #required: false
-      #example/g "8"
+      #example: "8"
       #default: '11'
       selector:
         number:
@@ -469,7 +469,7 @@ blueprint:
       name: Effect Color
       description: Color of LED effect
       #required: false
-      #example/g Red
+      #example: Red
       #default: 'no change'
       selector:
         select:
@@ -1317,8 +1317,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if  is_device_attr(ent,'model','LZW30') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
+                {% if  is_device_attr(ent,'model','LZW30') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1328,8 +1330,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if  is_device_attr(ent,'model','LZW31') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
+                {% if  is_device_attr(ent,'model','LZW31') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1339,8 +1343,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'LZW30-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
+                {% if 'LZW30-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1350,8 +1356,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'LZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
+                {% if 'LZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1361,8 +1369,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
+                {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1372,8 +1382,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zwave_js') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
+                {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zwave_js') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1384,8 +1396,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'VZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
+                {% if 'VZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1399,7 +1413,7 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
                 {% if ('2-in-1 switch' in device_attr(ent,'model') or is_device_attr(ent,'model_id','VZM31-SN')) and ent.split('.')[0] == 'light' and ent in integration_entities('mqtt') %}
                   {% set entities.entities = entities.entities + [ent] %}
                 {% endif %}
@@ -1413,7 +1427,7 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
                 {% if ('fan controller' in (device_attr(ent,'model')|lower) or is_device_attr(ent,'model_id','VZM35-SN')) and ent.split('.')[0] == 'fan' and ent in integration_entities('mqtt') %}
                   {% set entities.entities = entities.entities + [ent] %}
                 {% endif %}
@@ -1430,7 +1444,7 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
                 {% if 'VZM31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zha') %}
                   {% set entities.entities = entities.entities + [ent] %}
                 {% endif %}
@@ -1444,7 +1458,7 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
                 {% if 'VZM35-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zha') %}
                   {% set entities.entities = entities.entities + [ent] %}
                 {% endif %}

--- a/blueprints/script/kschlichter/inovelli_led_blueprint.yaml
+++ b/blueprints/script/kschlichter/inovelli_led_blueprint.yaml
@@ -30,8 +30,8 @@
 #
 # Convert to blueprint:
 #   Switch blueprint: and script alias: lines
-#   Add two spaces to lines between label: and variables: 67,494s
-#   Comment out #example:
+#   Add two spaces to lines between label: and variables: 67,495s
+#   Comment out #example/g
 #   Switch input_* and script variables in all three locations
 #
 # Zigbee2MQTT devices: https://www.zigbee2mqtt.io/supported-devices/#v=Inovelli
@@ -64,14 +64,14 @@ blueprint:
 #    through the Zwave JS, ZHA, and Zigbee2MQTT integrations.  Devices from all series can be used together,
 #    and can be called by floor, area, group, device, and entity.
 #fields:
-
+  
   
     label:
       name: Label
       description: Labels on Inovelli devices and entities, or areas containing Inovelli devices.
       #required: false
-      #example: 'christmas lights, bedrooms, fans'
-      default: 'invalid'
+      #example/g 'christmas lights, bedrooms, fans'
+      #default: 'invalid'
       selector:
         label:
           multiple: true
@@ -80,8 +80,8 @@ blueprint:
       name: Floor
       description: Floor IDs containing areas with Inovelli devices.  
       #required: false
-      #example: 'downstairs,upstairs, outside'
-      default: 'invalid'
+      #example/g 'downstairs,upstairs, outside'
+      #default: 'invalid'
       selector:
         floor:
           multiple: true
@@ -133,8 +133,8 @@ blueprint:
       name: Area
       description: Area names or IDs containing Inovelli devices.
       #required: false
-      #example: 'Family Room, 7d7a44fe4d0f4bee947c430d2714e45c'
-      default: 'invalid'
+      #example/g 'Family Room, 7d7a44fe4d0f4bee947c430d2714e45c'
+      #default: 'invalid'
       selector:
         area:
           multiple: true
@@ -187,8 +187,8 @@ blueprint:
       name: Group
       description: Group names or IDs for groups containing Inovelli devices.  Mix and match types as you like.
       #required: false
-      #example: 'group.lights_and_switches, 0249abdc634c12cbf6cdc06d7a507495'
-      default: 'invalid'
+      #example/g 'group.lights_and_switches, 0249abdc634c12cbf6cdc06d7a507495'
+      #default: 'invalid'
       selector:
         entity:
           multiple: true
@@ -203,8 +203,8 @@ blueprint:
       name: Device
       description: Device IDs of Inovelli devices.  Mix and match types as you like.
       #required: false
-      #example: '0249abdc634c12cbf6cdc06d7a507495'
-      default: 'invalid'
+      #example/g '0249abdc634c12cbf6cdc06d7a507495'
+      #default: 'invalid'
       selector:
         device:
           multiple: true
@@ -259,8 +259,8 @@ blueprint:
         The light.*, switch.*, or fan.* entity for the LED we're setting.  Can be
         a comma separated list of Inovelli devices.  Mix and match types as you like.
       #required: false
-      #example: light.office, fan.guest_room
-      default: 'invalid'
+      #example/g light.office, fan.guest_room
+      #default: 'invalid'
       selector:
         entity:
           multiple: true
@@ -276,8 +276,8 @@ blueprint:
       description: >-
         Sets the full LED bar by default, or specific LEDs (1 – 7) starting at the bottom.
       #required: false
-      #example: All
-      default: 'all'
+      #example/g All
+      #default: 'all'
       selector:
         select:
           options:
@@ -294,8 +294,8 @@ blueprint:
       name: LED Color When On (non-effect)
       description: Sets the color of the LED status, which indicates brightness levels.
       #required: false
-      #example: Blue
-      default: 'no change'
+      #example/g Blue
+      #default: 'no change'
       selector:
         select:
           options:
@@ -323,8 +323,8 @@ blueprint:
       name: LED Color When Off (non-effect). Red 800 and Blue Series only.
       description: Sets the color of the LED status, which indicates brightness levels.
       #required: false
-      #example: Blue
-      default: 'no change'
+      #example/g Blue
+      #default: 'no change'
       selector:
         select:
           options:
@@ -352,8 +352,8 @@ blueprint:
       name: LED Brightness When On (non-effect)
       description: Sets the brightness of the LED status when on. 0 means off.
       #required: false
-      #example: "6"
-      default: '11'
+      #example/g "6"
+      #default: '11'
       selector:
         number:
           min: 0
@@ -365,8 +365,8 @@ blueprint:
       name: LED Brightness When Off (non-effect).
       description: Sets the brightness of the LED status when off. 0 means off.
       #required: false
-      #example: "2"
-      default: '11'
+      #example/g "2"
+      #default: '11'
       selector:
         number:
           min: 0
@@ -378,8 +378,8 @@ blueprint:
       name: Duration of Effect
       description: How long the effect will last.
       #required: false
-      #example: "Off"
-      default: '0'
+      #example/g "Off"
+      #default: '0'
       selector:
         select:
           options:
@@ -425,8 +425,8 @@ blueprint:
       name: Effect
       description: Type of effect
       #required: false
-      #example: Pulse
-      default: 'Clear Effect'
+      #example/g Pulse
+      #default: 'Clear Effect'
       selector:
         select:
           options:
@@ -456,8 +456,8 @@ blueprint:
       name: Effect Brightness
       description: Sets the brightness of the LED's effect.  0 means off.
       #required: false
-      #example: "8"
-      default: '11'
+      #example/g "8"
+      #default: '11'
       selector:
         number:
           min: 0
@@ -469,8 +469,8 @@ blueprint:
       name: Effect Color
       description: Color of LED effect
       #required: false
-      #example: Red
-      default: 'no change'
+      #example/g Red
+      #default: 'no change'
       selector:
         select:
           options:
@@ -1399,8 +1399,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if ('2-in-1 switch' in device_attr(ent,'model') or is_device_attr(ent,'model_id','VZM31-SN')) and ent.split('.')[0] == 'light' and ent in integration_entities('mqtt') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+                {% if ('2-in-1 switch' in device_attr(ent,'model') or is_device_attr(ent,'model_id','VZM31-SN')) and ent.split('.')[0] == 'light' and ent in integration_entities('mqtt') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1411,8 +1413,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if ('fan controller' in (device_attr(ent,'model')|lower) or is_device_attr(ent,'model_id','VZM35-SN')) and ent.split('.')[0] == 'fan' and ent in integration_entities('mqtt') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+                {% if ('fan controller' in (device_attr(ent,'model')|lower) or is_device_attr(ent,'model_id','VZM35-SN')) and ent.split('.')[0] == 'fan' and ent in integration_entities('mqtt') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1426,8 +1430,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'VZM31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zha') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+                {% if 'VZM31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zha') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1438,8 +1444,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'VZM35-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zha') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+                {% if 'VZM35-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zha') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -1122,7 +1122,7 @@ variables:
       {% for floor in floor_array.floor_list %}
         {% for area in floor_areas(floor) %}
           {% for ent in area_entities(area) %}
-            {% if ent.split('.')[0] in allowed_domains %}
+            {% if ent.split('.')[0] in allowed_domains and is_device_attr(ent,"manufacturer","Inovelli") %}
               {% set entities.entities = entities.entities + [ent|string|trim] %}
             {% endif %}
           {% endfor %}
@@ -1164,7 +1164,7 @@ variables:
       {# Detecting entities #}
       {% for area in area_array.area_list %}
         {% for ent in area_entities(area) %}
-          {% if ent.split('.')[0] in allowed_domains %}
+          {% if ent.split('.')[0] in allowed_domains and is_device_attr(ent,"manufacturer","Inovelli") %}
             {% set entities.entities = entities.entities + [ent|string|trim] %}
           {% endif %}
         {% endfor %}
@@ -1193,7 +1193,7 @@ variables:
       {% for group in group_array.group_list %}
         {% for entity in expand(group) %}
           {% set ent = entity.entity_id %}
-          {% if ent.split('.')[0] in allowed_domains %}
+          {% if ent.split('.')[0] in allowed_domains and is_device_attr(ent,"manufacturer","Inovelli") %}
             {% set entities.entities = entities.entities + [ent|string|trim] %}
           {% endif %}
         {% endfor %}
@@ -1230,7 +1230,7 @@ variables:
       {# Detecting entities #}
       {% for device in devices.devices %}
         {% for ent in device_entities(device) %}
-          {% if ent.split('.')[0] in allowed_domains %}
+          {% if ent.split('.')[0] in allowed_domains and is_device_attr(ent,"manufacturer","Inovelli") %}
             {% set entities.entities = entities.entities + [ent|string|trim] %}
           {% endif %}
         {% endfor %}
@@ -1265,7 +1265,7 @@ variables:
 
       {# Detecting entities #}
       {% for ent in entities_array.entities %}
-        {% if ent.split('.')[0] in allowed_domains %}
+        {% if ent.split('.')[0] in allowed_domains and is_device_attr(ent,"manufacturer","Inovelli") %}
           {% set entities.entities = entities.entities + [ent|string|trim] %}
         {% endif %}
       {% endfor %}
@@ -1317,10 +1317,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if  is_device_attr(ent,'model','LZW30') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if  is_device_attr(ent,'model','LZW30') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1330,10 +1328,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if  is_device_attr(ent,'model','LZW31') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if  is_device_attr(ent,'model','LZW31') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1343,10 +1339,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if 'LZW30-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if 'LZW30-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1356,10 +1350,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if 'LZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if 'LZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1369,10 +1361,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1382,10 +1372,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zwave_js') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zwave_js') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1396,10 +1384,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if 'VZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if 'VZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1413,10 +1399,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if ('2-in-1 switch' in device_attr(ent,'model') or is_device_attr(ent,'model_id','VZM31-SN')) and ent.split('.')[0] == 'light' and ent in integration_entities('mqtt') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if ('2-in-1 switch' in device_attr(ent,'model') or is_device_attr(ent,'model_id','VZM31-SN')) and ent.split('.')[0] == 'light' and ent in integration_entities('mqtt') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1427,10 +1411,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if ('fan controller' in (device_attr(ent,'model')|lower) or is_device_attr(ent,'model_id','VZM35-SN')) and ent.split('.')[0] == 'fan' and ent in integration_entities('mqtt') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if ('fan controller' in (device_attr(ent,'model')|lower) or is_device_attr(ent,'model_id','VZM35-SN')) and ent.split('.')[0] == 'fan' and ent in integration_entities('mqtt') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1444,10 +1426,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if 'VZM31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zha') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if 'VZM31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zha') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1458,10 +1438,8 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
-                {% if 'VZM35-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zha') %}
-                  {% set entities.entities = entities.entities + [ent] %}
-                {% endif %}
+              {% if 'VZM35-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zha') %}
+                {% set entities.entities = entities.entities + [ent] %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -1317,8 +1317,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if  is_device_attr(ent,'model','LZW30') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
+                {% if  is_device_attr(ent,'model','LZW30') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1328,8 +1330,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if  is_device_attr(ent,'model','LZW31') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
+                {% if  is_device_attr(ent,'model','LZW31') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1339,8 +1343,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'LZW30-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
+                {% if 'LZW30-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'switch' and ent in integration_entities('zwave_js') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1350,8 +1356,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'LZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
+                {% if 'LZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1361,8 +1369,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
+                {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1372,8 +1382,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zwave_js') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
+                {% if 'LZW36' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zwave_js') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1384,8 +1396,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'VZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
+                {% if 'VZW31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zwave_js') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1399,7 +1413,7 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
                 {% if ('2-in-1 switch' in device_attr(ent,'model') or is_device_attr(ent,'model_id','VZM31-SN')) and ent.split('.')[0] == 'light' and ent in integration_entities('mqtt') %}
                   {% set entities.entities = entities.entities + [ent] %}
                 {% endif %}
@@ -1413,7 +1427,7 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
                 {% if ('fan controller' in (device_attr(ent,'model')|lower) or is_device_attr(ent,'model_id','VZM35-SN')) and ent.split('.')[0] == 'fan' and ent in integration_entities('mqtt') %}
                   {% set entities.entities = entities.entities + [ent] %}
                 {% endif %}
@@ -1430,7 +1444,7 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
                 {% if 'VZM31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zha') %}
                   {% set entities.entities = entities.entities + [ent] %}
                 {% endif %}
@@ -1444,7 +1458,7 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+              {% if is_device_attr(ent,"manufacturer","Inovelli") %}
                 {% if 'VZM35-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zha') %}
                   {% set entities.entities = entities.entities + [ent] %}
                 {% endif %}

--- a/inovelli_led.yaml
+++ b/inovelli_led.yaml
@@ -30,7 +30,7 @@
 #
 # Convert to blueprint:
 #   Switch blueprint: and script alias: lines
-#   Add two spaces to lines between label: and variables: 67,494s
+#   Add two spaces to lines between label: and variables: 67,495s
 #   Comment out example:
 #   Switch input_* and script variables in all three locations
 #
@@ -49,7 +49,7 @@ max: 100 # Default max is 10, which might be an issue if you have a lot of switc
 #  name: Inovelli LED Settings and Effects Blueprint
 #  domain: script
 #  source_url: https://github.com/kschlichter/Home-Assistant-Inovelli-Effects-and-Colors/blob/Blueprint/blueprints/script/kschlichter/inovelli_led_blueprint.yaml
-#  author: Kevin Schlichter
+#  author: "Kevin Schlichter"
 #  description: >-
 #    Sets LED colors and effects on Inovelli "Black", "Red 500", "Red 800", and "Blue" Series switches, dimmers, and fan controllers
 #    through the Zwave JS, ZHA, and Zigbee2MQTT integrations.  Devices from all series can be used together,
@@ -1399,8 +1399,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if ('2-in-1 switch' in device_attr(ent,'model') or is_device_attr(ent,'model_id','VZM31-SN')) and ent.split('.')[0] == 'light' and ent in integration_entities('mqtt') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+                {% if ('2-in-1 switch' in device_attr(ent,'model') or is_device_attr(ent,'model_id','VZM31-SN')) and ent.split('.')[0] == 'light' and ent in integration_entities('mqtt') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1411,8 +1413,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if ('fan controller' in (device_attr(ent,'model')|lower) or is_device_attr(ent,'model_id','VZM35-SN')) and ent.split('.')[0] == 'fan' and ent in integration_entities('mqtt') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+                {% if ('fan controller' in (device_attr(ent,'model')|lower) or is_device_attr(ent,'model_id','VZM35-SN')) and ent.split('.')[0] == 'fan' and ent in integration_entities('mqtt') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1426,8 +1430,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'VZM31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zha') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+                {% if 'VZM31-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'light' and ent in integration_entities('zha') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}
@@ -1438,8 +1444,10 @@ sequence:
           entities: >-
             {% set entities = namespace(entities=[]) %}
             {% for ent in all_selected_entities %}
-              {% if 'VZM35-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zha') %}
-                {% set entities.entities = entities.entities + [ent] %}
+              {% if device_attr(ent,'model') is not none and device_attr(ent,'model_id') is not none %}
+                {% if 'VZM35-SN' in device_attr(ent,'model') and ent.split('.')[0] == 'fan' and ent in integration_entities('zha') %}
+                  {% set entities.entities = entities.entities + [ent] %}
+                {% endif %}
               {% endif %}
             {% endfor %}
             {{ entities.entities }}


### PR DESCRIPTION
Devices with no device attribute for manufacturer or model will no longer generate "none type" errors.