### PR TITLE
Change Default to brackets

### DIFF
--- a/blueprints/script/kschlichter/inovelli_led_blueprint.yaml
+++ b/blueprints/script/kschlichter/inovelli_led_blueprint.yaml
@@ -71,7 +71,7 @@ blueprint:
       description: Labels on Inovelli devices and entities, or areas containing Inovelli devices.
       #required: false
       #example: 'christmas lights, bedrooms, fans'
-      default: 'invalid'
+      default: []
       selector:
         label:
           multiple: true
@@ -81,7 +81,7 @@ blueprint:
       description: Floor IDs containing areas with Inovelli devices.  
       #required: false
       #example: 'downstairs,upstairs, outside'
-      default: 'invalid'
+      default: []
       selector:
         floor:
           multiple: true
@@ -134,7 +134,7 @@ blueprint:
       description: Area names or IDs containing Inovelli devices.
       #required: false
       #example: 'Family Room, 7d7a44fe4d0f4bee947c430d2714e45c'
-      default: 'invalid'
+      default: []
       selector:
         area:
           multiple: true
@@ -188,7 +188,7 @@ blueprint:
       description: Group names or IDs for groups containing Inovelli devices.  Mix and match types as you like.
       #required: false
       #example: 'group.lights_and_switches, 0249abdc634c12cbf6cdc06d7a507495'
-      default: 'invalid'
+      default: []
       selector:
         entity:
           multiple: true
@@ -204,7 +204,7 @@ blueprint:
       description: Device IDs of Inovelli devices.  Mix and match types as you like.
       #required: false
       #example: '0249abdc634c12cbf6cdc06d7a507495'
-      default: 'invalid'
+      default: []
       selector:
         device:
           multiple: true
@@ -260,7 +260,7 @@ blueprint:
         a comma separated list of Inovelli devices.  Mix and match types as you like.
       #required: false
       #example: light.office, fan.guest_room
-      default: 'invalid'
+      default: []
       selector:
         entity:
           multiple: true


### PR DESCRIPTION
Thanks for all the effort on this. I noticed that changing the value of default from 'invalid' to [] for the inputs appears to prevent invalid objects when creating scripts from the automation. 
